### PR TITLE
Updated fields and implemented addSection method

### DIFF
--- a/Models/Person.cs
+++ b/Models/Person.cs
@@ -1,36 +1,27 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace Registration.Models
 {
     public abstract class Person
     {
         protected int Id { get; set; }
         protected string firstName { get; set; }
-        protected string? middleName { get; set; }
+        protected string middleName { get; set; }
         protected string lastName { get; set; }
         protected string gender { get; set; }
         protected int birthMonth { get; set; }
         protected int birthDay { get; set; }
         protected int birthYear { get; set; }
-        protected string? email { get; set; }
-        protected string? areaCode { get; set; }
-        protected string? phoneNumber { get; set; }
+        protected string email { get; set; }
+        protected string areaCode { get; set; }
+        protected string phoneNumber { get; set; }
         protected string address { get; set; }
         protected string city { get; set; }
         protected string state { get; set; }
         protected int zip { get; set; }
 
-        protected Dictionary<string, List<Section>> schedule = new Dictionary<string, List<Section>> {
-            { "M", new List<Section>() },
-            { "T", new List<Section>() },
-            { "W", new List<Section>() },
-            { "Th", new List<Section>() },
-            { "F", new List<Section>() },
-            { "Sa", new List<Section>() }
-        };
+        protected Dictionary<string, List<Section>> schedule;
 
         // Constructor with optional arguments
-        public Person(string firstName, string lastName, string gender, int birthMonth, int birthDay, int birthYear, string address, string city, string state, int zip, string middleName = "", string email = "", string areaCode = "", string phoneNumber = "")
+        public Person(string firstName, string lastName, string gender, int birthMonth, int birthDay, int birthYear, string address, string city, string state, int zip, Dictionary<string, List<Section>>? schedule = null, string middleName = "", string email = "", string areaCode = "", string phoneNumber = "")
         {
             this.firstName = firstName;
             this.middleName = middleName;
@@ -46,6 +37,24 @@ namespace Registration.Models
             this.email = email;
             this.areaCode = areaCode;
             this.phoneNumber = phoneNumber;
+            this.schedule = schedule != null ? schedule : new Dictionary<string, List<Section>> {
+                                                            { "M", new List<Section>() },
+                                                            { "T", new List<Section>() },
+                                                            { "W", new List<Section>() },
+                                                            { "Th", new List<Section>() },
+                                                            { "F", new List<Section>() },
+                                                            { "Sa", new List<Section>() }
+                                                        };
+        }
+
+        public void addSection(Section section)
+        {
+            var days = section.classDays;
+            foreach (string day in days)
+            {
+                List<Section> dailySchedule = schedule[day];
+                dailySchedule.Add(section);
+            }
         }
 
         public abstract Boolean availability(Section section);


### PR DESCRIPTION
Changed the `Dictionary` for schedule to be a pointer vs. a blank `Dictionary`.

I changed the constructor to set the `Dictionary` to null as an optional parameter for schedule if it's not provided upon instantiation. The ternary will then check whether or not the `Dictionary` object `schedule` is `null`. If is not `null` then it will have the pointer point to that object. But, if it is null then it will create a `new Dictionary` with 6 keys:

1. "M" to represent Monday.
2. "T" to represent Tuesday.
3. "W" to represent Wednesday.
4. "Th" to represent Thursday.
5. "F" to represent Friday.
6. "Sa" to represent Saturday.

Each day will contain a `List` of [Section](https://github.com/chizuo/COMP586-Project/blob/main/Models/Section.cs) objects, which represents the classes that the [Person](https://github.com/chizuo/COMP586-Project/blob/main/Models/Person.cs) has for their schedule for that given day.

I implemented a method called `addSection` since both [Student](https://github.com/chizuo/COMP586-Project/blob/classPerson/Models/Student.cs) and [Professor](https://github.com/chizuo/COMP586-Project/blob/classPerson/Models/Professor.cs) would both need to have that feature. So it makes more sense to implement it here and have those classes inherit it.