### PR TITLE
removeSection Added 

### DIFF
--- a/Models/Person.cs
+++ b/Models/Person.cs
@@ -63,11 +63,11 @@ namespace Registration.Models
            string [] daysOfOperation = section.classDays; //retrieving the days for sections
             
             foreach(string courseDay in daysOfOperation){ //for each day that the section occurs
-                List<Section> dailySchedule = schedule[courseDay]; //retrieving the scheduled days the section occurs on
+                List<Section> dailySchedule = schedule[courseDay]; //retrieves the list that represent's courseDay's schedule of Sections.
                 int index = 0;
-                foreach(Section sections in dailySchedule){ //iterating through the persons schedule of sections in each day that contains the section that needs to be removed
+                foreach(Section sections in dailySchedule){ //iterating through the List of Sections for the Person's dailySchedule
   
-                    if(sections.classSectionNumber==sectionCode){ //if that day contains the section number we want -> remove it, otherwise break, and check the next day (index)
+                    if(sections.classSectionNumber==sectionCode){ //if that section contains the sectionNumber we want -> remove it and break out of the current dailySchedule, and check the next day (index)
                         dailySchedule.RemoveAt(index); 
                         functionCheck++;
                         break;

--- a/Models/Person.cs
+++ b/Models/Person.cs
@@ -57,6 +57,29 @@ namespace Registration.Models
             }
         }
 
+         public Boolean removeSection(Section section){
+           int functionCheck=0; //incremented each time a section is removed 
+           int sectionCode = section.classSectionNumber; //retrieving the section's section number 
+           string [] daysOfOperation = section.classDays; //retrieving the days for sections
+            
+            foreach(string courseDay in daysOfOperation){ //for each day that the section occurs
+                List<Section> dailySchedule = schedule[courseDay]; //retrieving the scheduled days the section occurs on
+                int index = 0;
+                foreach(Section sections in dailySchedule){ //iterating through the persons schedule of sections in each day that contains the section that needs to be removed
+  
+                    if(sections.classSectionNumber==sectionCode){ //if that day contains the section number we want -> remove it, otherwise break, and check the next day (index)
+                        dailySchedule.RemoveAt(index); 
+                        functionCheck++;
+                        break;
+                    }
+                    index++;
+                }
+            }
+            if(functionCheck==daysOfOperation.Length){return true;} //when the functionChecker is equal to the number of sections removed -> 
+                                                                    //return true, ensuring successful removal of the section passed 
+            return false; //this function should never return false
+        }
+
         public Boolean scheduler(Section section)
         {
             var scheduler = new List<List<Section>>();

--- a/Models/Person.cs
+++ b/Models/Person.cs
@@ -59,7 +59,6 @@ namespace Registration.Models
 
          public Boolean removeSection(Section section){
            int functionCheck=0; //incremented each time a section is removed 
-           int sectionCode = section.classSectionNumber; //retrieving the section's section number 
            string [] daysOfOperation = section.classDays; //retrieving the days for sections
             
             foreach(string courseDay in daysOfOperation){ //for each day that the section occurs
@@ -67,7 +66,7 @@ namespace Registration.Models
                 int index = 0;
                 foreach(Section sections in dailySchedule){ //iterating through the List of Sections for the Person's dailySchedule
   
-                    if(sections.classSectionNumber==sectionCode){ //if that section contains the sectionNumber we want -> remove it and break out of the current dailySchedule, and check the next day (index)
+                    if(sections.classSectionNumber == section.classSectionNumber){ //if that section contains the sectionNumber we want -> remove it and break out of the current dailySchedule, and check the next day (index)
                         dailySchedule.RemoveAt(index); 
                         functionCheck++;
                         break;

--- a/Models/Professor.cs
+++ b/Models/Professor.cs
@@ -9,5 +9,27 @@ namespace Registration.Models
         {
             this.semesterSections = semesterSections != null ? semesterSections : new Dictionary<string, Section>();
         }
+        public Boolean removeSection(Section section){
+           int functionCheck=0; //incremented each time a section is removed 
+           int sectionCode = section.classSectionNumber; //retrieving the section's section number 
+           string [] daysOfOperation = section.classDays; //retrieving the days for sections
+            
+            foreach(string courseDay in daysOfOperation){ //for each day that the section occurs
+                List<Section> dailySchedule = schedule[courseDay]; //retrieving the scheduled days the section occurs on
+                int index = 0;
+                foreach(Section sections in dailySchedule){ //iterating through the persons schedule of sections in each day that contains the section that needs to be removed
+  
+                    if(sections.classSectionNumber==sectionCode){ //if that day contains the section number we want -> remove it, otherwise break, and check the next day (index)
+                        dailySchedule.RemoveAt(index); 
+                        functionCheck++;
+                        break;
+                    }
+                    index++;
+                }
+            }
+            if(functionCheck==daysOfOperation.Length){return true;} //when the functionChecker is equal to the number of sections removed -> 
+                                                                    //return true, ensuring successful removal of the section passed 
+            return false; //this function should never return false
+        }
     }
 }

--- a/Models/Professor.cs
+++ b/Models/Professor.cs
@@ -9,27 +9,5 @@ namespace Registration.Models
         {
             this.semesterSections = semesterSections != null ? semesterSections : new Dictionary<string, Section>();
         }
-        public Boolean removeSection(Section section){
-           int functionCheck=0; //incremented each time a section is removed 
-           int sectionCode = section.classSectionNumber; //retrieving the section's section number 
-           string [] daysOfOperation = section.classDays; //retrieving the days for sections
-            
-            foreach(string courseDay in daysOfOperation){ //for each day that the section occurs
-                List<Section> dailySchedule = schedule[courseDay]; //retrieving the scheduled days the section occurs on
-                int index = 0;
-                foreach(Section sections in dailySchedule){ //iterating through the persons schedule of sections in each day that contains the section that needs to be removed
-  
-                    if(sections.classSectionNumber==sectionCode){ //if that day contains the section number we want -> remove it, otherwise break, and check the next day (index)
-                        dailySchedule.RemoveAt(index); 
-                        functionCheck++;
-                        break;
-                    }
-                    index++;
-                }
-            }
-            if(functionCheck==daysOfOperation.Length){return true;} //when the functionChecker is equal to the number of sections removed -> 
-                                                                    //return true, ensuring successful removal of the section passed 
-            return false; //this function should never return false
-        }
     }
 }


### PR DESCRIPTION
removeSection method added in Person.cs 
This method allows the derived classes, Student & Professor the ability to remove a section from their schedule.
By unpacking the schedule, this method finds the day(s) that the section occurs and checks those days for the section's respective sectionNumber. If found, it'll remove the section from that day and continue on until the section is removed from each of its scheduled day(s).