### PR TITLE
Update professor

### DIFF
--- a/Models/Professor.cs
+++ b/Models/Professor.cs
@@ -2,12 +2,12 @@ namespace Registration.Models
 {
     public class Professor : Person
     {
-        List<Section>? semesterSections;
+        Dictionary<string, Section>? semesterSections;
 
-        public Professor(string firstName, string lastName, string gender, int birthMonth, int birthDay, int birthYear, string address, string city, string state, int zip, string personType, Dictionary<string, List<Section>>? schedule = null, string middleName = "", string email = "", string areaCode = "", string phoneNumber = "", List<Section>? semesterSections = null)
+        public Professor(string firstName, string lastName, string gender, int birthMonth, int birthDay, int birthYear, string address, string city, string state, int zip, string personType, Dictionary<string, List<Section>>? schedule = null, string middleName = "", string email = "", string areaCode = "", string phoneNumber = "", Dictionary<string, Section>? semesterSections = null)
          : base(firstName, lastName, gender, birthMonth, birthDay, birthYear, address, city, state, zip, personType, schedule = null, middleName = "", email = "", areaCode = "", phoneNumber = "")
         {
-            this.semesterSections = semesterSections != null ? semesterSections : new List<Section>();
+            this.semesterSections = semesterSections != null ? semesterSections : new Dictionary<string, Section>();
         }
     }
 }

--- a/Models/Professor.cs
+++ b/Models/Professor.cs
@@ -2,9 +2,12 @@ namespace Registration.Models
 {
     public class Professor : Person
     {
-        public Professor(string firstName, string lastName, string gender, int birthMonth, int birthDay, int birthYear, string address, string city, string state, int zip, string personType, Dictionary<string, List<Section>>? schedule = null, string middleName = "", string email = "", string areaCode = "", string phoneNumber = "")
+        List<Section>? semesterSections;
+
+        public Professor(string firstName, string lastName, string gender, int birthMonth, int birthDay, int birthYear, string address, string city, string state, int zip, string personType, Dictionary<string, List<Section>>? schedule = null, string middleName = "", string email = "", string areaCode = "", string phoneNumber = "", List<Section>? semesterSections = null)
          : base(firstName, lastName, gender, birthMonth, birthDay, birthYear, address, city, state, zip, personType, schedule = null, middleName = "", email = "", areaCode = "", phoneNumber = "")
         {
+            this.semesterSections = semesterSections != null ? semesterSections : new List<Section>();
         }
     }
 }


### PR DESCRIPTION
Currently, for the [`Professor`](https://github.com/chizuo/COMP586-Project/blob/main/Models/Professor.cs) object to be able to interact with the [`Section`](https://github.com/chizuo/COMP586-Project/blob/main/Models/Section.cs)s they are teaching, we have to search for `Section` object in the schedule, which can be a very expensive search. By adding this `Dictionary<string, Section> semesterSection` in `Professor` we can treat it as a cache to get quick access to the `Section` objects.