### PR TITLE
Implemented addProfessor and professorFullName methods in the Section…

### DIFF
--- a/Models/Person.cs
+++ b/Models/Person.cs
@@ -2,22 +2,22 @@ namespace Registration.Models
 {
     public abstract class Person
     {
-        protected int Id { get; set; }
-        protected string firstName { get; set; }
-        protected string middleName { get; set; }
-        protected string lastName { get; set; }
-        protected string gender { get; set; }
-        protected int birthMonth { get; set; }
-        protected int birthDay { get; set; }
-        protected int birthYear { get; set; }
-        protected string email { get; set; }
-        protected string areaCode { get; set; }
-        protected string phoneNumber { get; set; }
-        protected string address { get; set; }
-        protected string city { get; set; }
-        protected string state { get; set; }
-        protected int zip { get; set; }
-        protected string personType { get; set; }
+        protected int Id;
+        protected string firstName;
+        protected string middleName;
+        protected string lastName;
+        protected string gender;
+        protected int birthMonth;
+        protected int birthDay;
+        protected int birthYear;
+        protected string email;
+        protected string areaCode;
+        protected string phoneNumber;
+        protected string address;
+        protected string city;
+        protected string state;
+        protected int zip;
+        protected string personType;
         protected Dictionary<string, List<Section>> schedule;
 
         // Constructor with optional arguments
@@ -130,6 +130,18 @@ namespace Registration.Models
             }
 
             return courseList;
+        }
+
+        public string getName()
+        {
+            if (middleName != "") return firstName + " " + middleName + " " + lastName;
+
+            return firstName + " " + lastName;
+        }
+
+        public int getId()
+        {
+            return Id;
         }
     }
 }

--- a/Models/Section.cs
+++ b/Models/Section.cs
@@ -87,7 +87,7 @@ namespace Registration.Models
             professor = prof;
             return true;
         }
-        public string professorFullName()
+        public string getProfessorFullName()
         {
             if (professor != null) return professor.getName();
 

--- a/Models/Section.cs
+++ b/Models/Section.cs
@@ -82,7 +82,7 @@ namespace Registration.Models
             }
         }
 
-        public bool addProfossor(Professor prof)
+        public bool addProfessor(Professor prof)
         {
             professor = prof;
             return true;

--- a/Models/Section.cs
+++ b/Models/Section.cs
@@ -4,6 +4,7 @@ namespace Registration.Models
     public class Section
     {
         protected Course course;
+        protected Professor professor;
         public int classSectionNumber;
         public string schoolYear;
         public string schoolTerm;
@@ -21,7 +22,7 @@ namespace Registration.Models
         public string classNote;
         public Dictionary<int, Boolean> addNumbers = new Dictionary<int, Boolean>();
 
-        public Section(Course course, int classSectionNumber, string schoolTerm, string schoolYear, int enrollmentCap, List<Student> enrollment, int waitListcap, int waitListTotal, string[] classDays, int startTime, int endTime, string classLocation, string classMeetingDates, string classNote, Dictionary<int, Boolean> addNumbers)
+        public Section(Course course, int classSectionNumber, string schoolTerm, string schoolYear, int enrollmentCap, List<Student> enrollment, int waitListcap, int waitListTotal, string[] classDays, int startTime, int endTime, string classLocation, string classMeetingDates, string classNote, Dictionary<int, Boolean> addNumbers, Professor professor = null)
         {
             this.course = course;
             this.classSectionNumber = classSectionNumber;
@@ -37,6 +38,7 @@ namespace Registration.Models
             this.classLocation = classLocation;
             this.classNote = classNote;
             this.addNumbers = addNumbers;
+            this.professor = professor;
         }
 
         public int generateAddNumber()
@@ -52,13 +54,14 @@ namespace Registration.Models
 
             return addNumber;
         }
-        
+
         public bool addStudent(Student student)
         {
-            if(enrollment.Count != enrollmentCap){
+            if (enrollment.Count != enrollmentCap)
+            {
                 enrollment.Add(student);
                 return true;
-            } 
+            }
             else
             {
                 return false;
@@ -67,7 +70,8 @@ namespace Registration.Models
 
         public bool addStudent(Student student, int addNumber)
         {
-            if(addNumbers.ContainsKey(addNumber) && addNumbers[addNumber] == false){
+            if (addNumbers.ContainsKey(addNumber) && addNumbers[addNumber] == false)
+            {
                 addNumbers[addNumber] = true;
                 enrollment.Add(student);
                 return true;
@@ -77,7 +81,19 @@ namespace Registration.Models
                 return false;
             }
         }
-        
+
+        public bool addProfossor(Professor prof)
+        {
+            professor = prof;
+            return true;
+        }
+        public string professorFullName()
+        {
+            if (professor != null) return professor.getName();
+
+            return "Staff";
+        }
+
         public string getCourseName()
         {
             return course.getName();


### PR DESCRIPTION
In the Person abstract class two return methods were implemented and removed getters and settlers from the protected fields instructed by @chizuo. getId and getName methods were implemented because Professor and Student class inherit from the Person class which contains protected fields. This means they won't be able to reference those fields that are set to protect. 

getId returns a Student or Professor ID depending on who is calling on the method. If a student calls on the method, the method going to return the student id. If a professor calls on the method, the method going to return the professor id.
 
getName return method has an if condition where if the student or professor has a middle name not set to an empty string then return the first name, middle name, and last name. if the middle name is set to an empty string then return the first name and last name.  

In the Section class, two methods were implemented addProfessor and profressorFullName. 

The protected Professor professor global field was added to the Section class. 

Added Professor professor optional parameter and set to null.

addProfessor method has an object parameter that gets past a professor object to be set to the protected Professor professor object field for the section and returns true. 

profFullName return method has an if condition where if the protected Professor object field is not equal to null then return the professor full name by invoking the getName method from Person class which will return the professor name. if the protected Professor object field is set to null then return "Staff" since there's no professor assigned to the section.