### PR TITLE
Implemented Course view

### DIFF
--- a/Controllers/CourseController.cs
+++ b/Controllers/CourseController.cs
@@ -6,21 +6,40 @@ namespace Registration.Controllers
 {
     public class CourseController : Controller
     {
-        static Dictionary<string, Course> db_courses = new Dictionary<string, Course>()
+
+
+        static Dictionary<string, Professor> db_professors = new Dictionary<string, Professor>()
         {
-            {"Comp380", new Course("Computer Science", 380, "Intro Senior Project", 3,"Concepts and techniques for systems engineering, requirements analysis, design, implementation and testing of large-scale computer systems.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp381", new Course("Computer Science", 381, "Software Engineer Lab", 3, "Software development lab of 3 hours per week for the group activities associated with COMP 380.",new HashSet<Course>(),new HashSet<Course>())},
-            {"Comp565", new Course("Computer Science", 565, "ADV Computer Graphics", 3, "This course will cover the theory, design, implementation, and application of advanced computer graphics environments.",new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp584", new Course("Computer Science", 584, "ADV Web Engineer", 3, "A study of the concepts, principles, techniques, and methods of Web engineering.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp586", new Course("Computer Science", 586, "OO Software DEV", 3, "Review of object oriented concepts. Comparison with functional methods.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp610", new Course("Computer Science", 610, "Data Strctures + Algorithms", 3,"Topics include: design strategies for data structures and algorithms; theoretical limits to space and time requirements time/space trade offs; open problems in the field", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp620", new Course("Computer Science", 620, "Computer System Architecture", 3,"Analysis and evaluation of individual computers, networks of computers and the programs which support their operation and use.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp615", new Course("Computer Science", 615, "Advanced Topics in Computation Theory", 3,"Languages and the theory of computation are studied in depth.", new HashSet<Course>(), new HashSet<Course>())},
+            {"123456789", new Professor(123456789, "Brandon", "Sorto", "Male", 01, 01, 1000, "45800 Challenger Way Spc 127",
+            "Lancaster", "CA", "93535", "Professor", null, middle:"",email:"brandon.sorto@csun.edu", areaCode:"310", phone:"455-8990")}
         };
 
-        public ActionResult index()
+        static Department comp = new Department("Computer Science", "COMP", db_professors["123456789"]);
+
+        static Dictionary<string, Course> db_courses = new Dictionary<string, Course>()
         {
-            return View(db_courses["Comp586"]);
+            {"COMP380", new Course(comp, 380, "Intro Senior Project", 3,"Concepts and techniques for systems engineering, requirements analysis, design, implementation and testing of large-scale computer systems.", new HashSet<Course>(), new HashSet<Course>())},
+            {"COMP381", new Course(comp, 381, "Software Engineer Lab", 3, "Software development lab of 3 hours per week for the group activities associated with COMP 380.",new HashSet<Course>(),new HashSet<Course>())},
+            {"COMP565", new Course(comp, 565, "ADV Computer Graphics", 3, "This course will cover the theory, design, implementation, and application of advanced computer graphics environments.",new HashSet<Course>(), new HashSet<Course>())},
+            {"COMP584", new Course(comp, 584, "ADV Web Engineer", 3, "A study of the concepts, principles, techniques, and methods of Web engineering.", new HashSet<Course>(), new HashSet<Course>())},
+            {"COMP586", new Course(comp, 586, "OO Software DEV", 3, "Review of object oriented concepts. Comparison with functional methods.", new HashSet<Course>(), new HashSet<Course>())},
+            {"COMP610", new Course(comp, 610, "Data Strctures + Algorithms", 3,"Topics include: design strategies for data structures and algorithms; theoretical limits to space and time requirements time/space trade offs; open problems in the field", new HashSet<Course>(), new HashSet<Course>())},
+            {"COMP620", new Course(comp, 620, "Computer System Architecture", 3,"Analysis and evaluation of individual computers, networks of computers and the programs which support their operation and use.", new HashSet<Course>(), new HashSet<Course>())},
+            {"COMP615", new Course(comp, 615, "Advanced Topics in Computation Theory", 3,"Languages and the theory of computation are studied in depth.", new HashSet<Course>(), new HashSet<Course>())},
+        };
+
+        static HashSet<Course> pre = new HashSet<Course>();
+        static HashSet<Course> co = new HashSet<Course>();
+
+        public ActionResult index(string? course = null)
+        {
+            pre.Add(db_courses["COMP380"]);
+            pre.Add(db_courses["COMP381"]);
+            co.Add(db_courses["COMP565"]);
+            db_courses["COMP586"].PreRequisites = pre;
+            db_courses["COMP586"].CoRequisites = co;
+            course = course != null ? course : "COMP586";
+            return View(db_courses[course]);
         }
     }
 }

--- a/Controllers/ProfessorController.cs
+++ b/Controllers/ProfessorController.cs
@@ -21,16 +21,18 @@ namespace Registration.Controllers
             {"4444", new Student(4444, "Carolina", "McGarity", "Male/Female", 01, 01, 1050, "Street address", "City Name", "State initals", "00000", "Student", null)},
         };
 
+        static Department comp = new Department("Computer Science", "COMP", db_professors["123456789"]);
+
         static Dictionary<string, Course> db_courses = new Dictionary<string, Course>()
         {
-            {"Comp380", new Course("Computer Science", 380, "Intro Senior Project", 3,"Concepts and techniques for systems engineering, requirements analysis, design, implementation and testing of large-scale computer systems.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp381", new Course("Computer Science", 381, "Software Engineer Lab", 3, "Software development lab of 3 hours per week for the group activities associated with COMP 380.",new HashSet<Course>(),new HashSet<Course>())},
-            {"Comp565", new Course("Computer Science", 565, "ADV Computer Graphics", 3, "This course will cover the theory, design, implementation, and application of advanced computer graphics environments.",new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp584", new Course("Computer Science", 584, "ADV Web Engineer", 3, "A study of the concepts, principles, techniques, and methods of Web engineering.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp586", new Course("Computer Science", 586, "OO Software DEV", 3, "Review of object oriented concepts. Comparison with functional methods.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp610", new Course("Computer Science", 610, "Data Strctures + Algorithms", 3,"Topics include: design strategies for data structures and algorithms; theoretical limits to space and time requirements time/space trade offs; open problems in the field", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp620", new Course("Computer Science", 620, "Computer System Architecture", 3,"Analysis and evaluation of individual computers, networks of computers and the programs which support their operation and use.", new HashSet<Course>(), new HashSet<Course>())},
-            {"Comp615", new Course("Computer Science", 615, "Advanced Topics in Computation Theory", 3,"Languages and the theory of computation are studied in depth.", new HashSet<Course>(), new HashSet<Course>())},
+            {"Comp380", new Course(comp, 380, "Intro Senior Project", 3,"Concepts and techniques for systems engineering, requirements analysis, design, implementation and testing of large-scale computer systems.", new HashSet<Course>(), new HashSet<Course>())},
+            {"Comp381", new Course(comp, 381, "Software Engineer Lab", 3, "Software development lab of 3 hours per week for the group activities associated with COMP 380.",new HashSet<Course>(),new HashSet<Course>())},
+            {"Comp565", new Course(comp, 565, "ADV Computer Graphics", 3, "This course will cover the theory, design, implementation, and application of advanced computer graphics environments.",new HashSet<Course>(), new HashSet<Course>())},
+            {"Comp584", new Course(comp, 584, "ADV Web Engineer", 3, "A study of the concepts, principles, techniques, and methods of Web engineering.", new HashSet<Course>(), new HashSet<Course>())},
+            {"Comp586", new Course(comp, 586, "OO Software DEV", 3, "Review of object oriented concepts. Comparison with functional methods.", new HashSet<Course>(), new HashSet<Course>())},
+            {"Comp610", new Course(comp, 610, "Data Strctures + Algorithms", 3,"Topics include: design strategies for data structures and algorithms; theoretical limits to space and time requirements time/space trade offs; open problems in the field", new HashSet<Course>(), new HashSet<Course>())},
+            {"Comp620", new Course(comp, 620, "Computer System Architecture", 3,"Analysis and evaluation of individual computers, networks of computers and the programs which support their operation and use.", new HashSet<Course>(), new HashSet<Course>())},
+            {"Comp615", new Course(comp, 615, "Advanced Topics in Computation Theory", 3,"Languages and the theory of computation are studied in depth.", new HashSet<Course>(), new HashSet<Course>())},
         };
 
         static Dictionary<string, Section> db_sections = new Dictionary<string, Section>()

--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -2,29 +2,34 @@ namespace Registration.Models
 {
     public class Course
     {
-        public string dept;
-        public int number;
-        public string name;
-        public int units;
+        protected Department department;
+        protected int number;
+        protected string subject;
+        public string Subject { get; }
+        public string Name { get { return department.Code + number.ToString() + " : " + subject; } }
+        public string Code { get { return department.Code + number.ToString(); } }
+        protected int units;
+        public int Units { get { return units; } }
+        protected bool lab;
+        public bool Lab { get; set; }
         public string description;
-        public HashSet<Course> preRequisites;
-        public HashSet<Course> coRequisites;
+        protected HashSet<Course> preRequisites;
+        public HashSet<Course> PreRequisites { set { preRequisites = value; } }
+        public List<Course> PreReq { get { return preRequisites.ToList(); } }
+        protected HashSet<Course> coRequisites;
+        public HashSet<Course> CoRequisites { set { coRequisites = value; } }
+        public List<Course> CoReq { get { return coRequisites.ToList(); } }
 
-        public Course(string deptName, int courseNumber, string courseName, int units, string courseDescription, HashSet<Course> preReq, HashSet<Course> coReq)
+        public Course(Department department, int number, string subject, int units, string courseDescription, HashSet<Course> preReq, HashSet<Course> coReq, bool lab = false)
         {
-            dept = deptName;
-            number = courseNumber;
-            name = courseName;
+            this.department = department;
+            this.number = number;
+            this.subject = subject;
             this.units = units;
-            description = courseDescription;
-            preRequisites = preReq;
-            coRequisites = coReq;
-        }
-
-        /* Method to concatenate certain fields to provide a catalog name for the course */
-        public string getName()
-        {
-            return dept + number.ToString() + ": " + name;
+            this.lab = lab;
+            this.description = courseDescription;
+            this.preRequisites = preReq;
+            this.coRequisites = coReq;
         }
 
         /* Method that checks if the student meets the requirement to take this course */
@@ -38,13 +43,13 @@ namespace Registration.Models
             /* Convert course object to course name for comparison */
             foreach (var course in preRequisites)
             {
-                preReqs.Add(course.getName());
+                preReqs.Add(course.Code);
             }
 
             /* Convert course object to course name for comparison */
             foreach (var course in coRequisites)
             {
-                coReqs.Add(course.getName());
+                coReqs.Add(course.Code);
             }
 
             foreach (var course in student.coursesPassed())

--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -7,12 +7,13 @@ namespace Registration.Models
         protected string subject;
         public string Subject { get; }
         public string Name { get { return department.Code + number.ToString() + " : " + subject; } }
-        public string Code { get { return department.Code + number.ToString(); } }
+        public string Code { get { return isLab == true ? department.Code + number.ToString() + "L" : department.Code + number.ToString(); } }
         protected int units;
         public int Units { get { return units; } }
-        protected bool lab;
-        public bool Lab { get; set; }
-        public string description;
+        protected bool isLab; /* identifies if this course is a lab */
+        public bool IsLab { get { return isLab; } }
+        internal Course lab; /* couse that is the lab component */
+        internal string description;
         protected HashSet<Course> preRequisites;
         public HashSet<Course> PreRequisites { set { preRequisites = value; } }
         public List<Course> PreReq { get { return preRequisites.ToList(); } }
@@ -20,7 +21,7 @@ namespace Registration.Models
         public HashSet<Course> CoRequisites { set { coRequisites = value; } }
         public List<Course> CoReq { get { return coRequisites.ToList(); } }
 
-        public Course(Department department, int number, string subject, int units, string courseDescription, HashSet<Course> preReq, HashSet<Course> coReq, bool lab = false)
+        public Course(Department department, int number, string subject, int units, string courseDescription, HashSet<Course> preReq, HashSet<Course> coReq, bool isLab = false)
         {
             this.department = department;
             this.number = number;

--- a/Models/Department.cs
+++ b/Models/Department.cs
@@ -1,0 +1,19 @@
+namespace Registration.Models
+{
+    public class Department
+    {
+        protected string name;
+        public string Name { get { return name; } }
+        protected string code;
+        public string Code { get { return code; } }
+        protected Professor professor;
+        public Professor Chair { get { return professor; } set { professor = value; } }
+
+        public Department(string name, string code, Professor professor)
+        {
+            this.name = name;
+            this.code = code;
+            this.professor = professor;
+        }
+    }
+}

--- a/Models/Section.cs
+++ b/Models/Section.cs
@@ -134,12 +134,12 @@ namespace Registration.Models
 
         public string getCourseName()
         {
-            return course.getName();
+            return course.Name;
         }
 
         public int getUnits()
         {
-            return course.units;
+            return course.Units;
         }
     }
 }

--- a/Models/Student.cs
+++ b/Models/Student.cs
@@ -2,7 +2,6 @@ namespace Registration.Models
 {
     public class Student : Person
     {
-
         protected List<Tuple<Section, double>> transcript;
         public List<Tuple<Section, double>> Transcript { get; set; }
         public double GPA { get { return overallGPA(); } }

--- a/Views/Course/Index.cshtml
+++ b/Views/Course/Index.cshtml
@@ -5,5 +5,17 @@
 }
 
 <div id="course">
-    <h1>Course @Model.dept @Model.number : @Model.name (@Model.units)</h1>
+    <h2 id="course-header"><span>Course:</span> @Model.Name (@Model.Units)</h2>
+    <hr>
+    <div id="course-card">
+        <div id="contents">
+            <p><span>Corequisites:</span> @foreach(var course in Model.PreReq){
+                <a href="./index?course=@course.Code">@course.Code</a>
+            }</p>
+            <p><span>Prerequisites:</span> @foreach(var course in Model.CoReq){
+                <a href="./index?course=@course.Code">@course.Code</a>
+            }</p></p>
+            <p><span>Description:</span> @Model.description</p>
+        </div>
+    </div>
 </div>

--- a/Views/Course/Index.cshtml
+++ b/Views/Course/Index.cshtml
@@ -9,10 +9,10 @@
     <hr>
     <div id="course-card">
         <div id="contents">
-            <p><span>Corequisites:</span> @foreach(var course in Model.PreReq){
+            <p><span>Corequisites:</span> @foreach(var course in Model.CoReq){
                 <a href="./index?course=@course.Code">@course.Code</a>
             }</p>
-            <p><span>Prerequisites:</span> @foreach(var course in Model.CoReq){
+            <p><span>Prerequisites:</span> @foreach(var course in Model.PreReq){
                 <a href="./index?course=@course.Code">@course.Code</a>
             }</p></p>
             <p><span>Description:</span> @Model.description</p>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -73,3 +73,32 @@ table#coursetable tr:nth-child(even) {
   background-color: #dddddd;
 }
 /*-------------------------*/
+
+/* Course View */
+#course {
+  width: 800px;
+}
+
+#course-header {
+  color: #55565A;
+  font-weight: bold;
+}
+
+#course-header span {
+  color: red;
+  font-weight: bolder;
+}
+
+#contents {
+  padding: 5px;
+}
+
+#course-card {
+  height: 400px;
+  box-shadow: 0px 12px 24px black;
+  transform: translateY(-2px)
+}
+
+#course-card span {
+  font-weight: bold;
+}


### PR DESCRIPTION
This feature implements the `Course` controller & view, respectively named [`CourseController`](https://github.com/chizuo/COMP586-Project/blob/main/Controllers/CourseController.cs) and [`Index.cshtml`](https://github.com/chizuo/COMP586-Project/blob/main/Views/Course/Index.cshtml).

The `CourseController`  only has one route, `index(string course)` which currently is permitted to be nullable for testing purposes. But, in the future, it will require a query string in the form of `https://localhost:7150/Course/index?course=string` where the string is `Course.Code`.  The `Course` view will require a `Course` object as its Model and will unbox the `Course.PreReq` and `Course.CoReq` to create links that will route to the same endpoint with a query string of the course found in each respective `List<Course`, that is the property `Couse.PreReq` and `Course.CoReq`. Once the database has been implemented with data to test, the `index(string course)` method will use the string as the unique ID to query the database for the course information. The `string course` represents the unique ID of the course entity in the Course Table of our database.

An additional feature added is the [`Department`](https://github.com/chizuo/COMP586-Project/pull/30/files#diff-83deb0674b8fcf82feb6d7ddbf1144e329b0ceb1803872e92259b2e8463fbd1a) class. This class was created to mimic the implementation we often see universities do. Though, for the scope of this project, it was really used to help make sense of how to create a `course.Code` since part of the code was based from the department's choice of acronym (e.g. Computer Science = COMP, Electrical and Computer Engineer = ECE) and the concatenation of the `Course.number`. I didn't think it made sense to require the creator of the `Course` to provide a `course.Code` in the constructor while also allowing free reign on choosing what the `Course.Code` would be, as it leads to possible shift in convention. Since we intend to use the `Course.Code` as the unique i.d. of the `Course`  entity in the Course Table in our database, it made more sense to enforce the convention through the application to prevent any possible collisions on the unique IDs that are not automatically generated by the database.

The `Department` class is comprised of:
```
protected string name; //representing the department name, like "Computer Science"
public string Name; //the property  that gives you access to read the department name, e.g. department.Name
protected string code; //representing the acronym of the department, e.g. "Computer Science" is "COMP"
public string Code; //the property that gives you access to read the acronym of the department.
protected Professor professor; //professor object that represents the chair of the department
public Professor Chair; //the property that returns or replaces the professor that is the chair of the department
```

The [`Course`](https://github.com/chizuo/COMP586-Project/blob/main/Models/Course.cs) class has been updated with the following changes:

- Removed getter methods and replaced them with properties to simplify the code and adhere more towards the C# convention of getters and setters for protected / private fields.
- changed the field `string courseName` to `string subject`.
- changed `string dept` to `Department department`, which is now an object of class `Department`
- created a property `public string Name` that returns the concat of the `department.Code` with the course number and subject for the purpose of simplifying the view portion of the application. E.g.`course.Name` would return something like "COMP586 : Object Oriented Design"/
- created a property 'public string Code' that returns the concat of the `department.Code` with the course number. This was done to help simplify the query string creation of any `View()` in the application that intends to route to the Course end point by using the Razor annotation `<a href="./Course/index?course=@course.Code">@course.Code</a>`
- created a property `public List<Course> CoReq` and `public List<Course> PreReq` for the purpose of creating a simple iterable object for the `View()` that intends to unbox and create clickable links for the course route by using the `Course` object property.
- created the properties `public HashSet<Course> PreRequisites` and `public HashSet<Course> CoRequisites` as the setters for a `Course` object's `coRequisites` and `preRequisites`
- created properties and fields related to lab. 
- `isLab` is used to identify that the course is a lab component, not lecture. Thus, the `course.Code` will append "L" at the end of the `course.Code`, e.g. "COMP586L"
- `Course lab` is the field that holds the lab component `Course` object. I'm deciding if this makes sense or if it makes more sense to just hold the `course.Code` of the lab component since it is always the `course.Code` with L appended to it.